### PR TITLE
Feat: Implement `WikipediaAPITool` to allow CrewAI agents to fetch content from Wikipedia

### DIFF
--- a/infra/crewai/tools/wikipedia_api_tool.py
+++ b/infra/crewai/tools/wikipedia_api_tool.py
@@ -1,0 +1,30 @@
+from typing import Any, Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel as PydanticBaseModel
+
+from infra.services.wikipedia_content_fetcher_service import \
+    WikipediaContentFetcherService
+from infra.types.wikipedia_content_request import WikipediaContentRequest
+from infra.types.wikipedia_content_response import WikipediaContentResponse
+
+
+class WikipediaAPITool(BaseTool):
+  name: str = "Wikipedia API Tool"
+  description: str = "A tool to fetch content from Wikipedia."
+  args_schema: Type[PydanticBaseModel] = WikipediaContentRequest
+  
+  def _run(self, topic: str) -> WikipediaContentResponse:
+    """
+    Fetches content from Wikipedia for the given topic.
+
+    Args:
+        topic (str): The topic to fetch content for.
+
+    Returns:
+        str: The fetched content.
+    """
+    wikipedia_service = WikipediaContentFetcherService()
+    request = WikipediaContentRequest(topic=topic)
+
+    return wikipedia_service.execute(request)


### PR DESCRIPTION
This pull request introduces a new tool to fetch content from Wikipedia. The main addition is the `WikipediaAPITool` class, which integrates with existing services and types to retrieve Wikipedia content based on a given topic.

Key changes include:

* **New class implementation:**
  * [`infra/crewai/tools/wikipedia_api_tool.py`](diffhunk://#diff-6c0604d792d7f10077415bef5bbb296005fd08e25008a65f74265a558dec4c8bR1-R30): Added the `WikipediaAPITool` class, which inherits from `BaseTool` and includes a method `_run` to fetch content from Wikipedia using the `WikipediaContentFetcherService`.
