### PR TITLE
Feat(routes): add root endpoint and article generation route

### DIFF
--- a/infra/http/routes/__init__.py
+++ b/infra/http/routes/__init__.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Query
+
+from core.types.article_content_response import ArticleContentResponse
+from infra.http.controllers.generate_article_controller import \
+    generate_article_controller
+from infra.types.wikipedia_content_request import WikipediaContentRequest
+
+router = APIRouter()
+
+@router.get("/article/generate", response_model=ArticleContentResponse)
+async def generate_article(
+    topic: WikipediaContentRequest = Query(...),
+) -> ArticleContentResponse:
+    """
+    Endpoint to generate an article based on the provided topic.
+    
+    Args:
+        topic (WikipediaContentRequest): The topic for the article to be generated.
+    
+    Returns:
+        ArticleContentResponse: The generated article content.
+    """
+    return await generate_article_controller(topic)


### PR DESCRIPTION
This pull request introduces a new endpoint to the FastAPI application for generating articles based on a provided topic. The most important changes include the creation of a new router, and the definition of the `generate_article` endpoint.

New endpoint implementation:

* [`infra/http/routes/__init__.py`](diffhunk://#diff-f52150ea3141473dd2db5e2ca9fb21b140b0f701af1afe065ca46d785f3aa8cdR1-R23): Defined a new router and the `generate_article` endpoint to generate articles based on a provided topic.